### PR TITLE
feat: 🚀 mlp.py MLPMixerLayer fix and test case added

### DIFF
--- a/kerasfuse/models/blocks/mlp.py
+++ b/kerasfuse/models/blocks/mlp.py
@@ -1,7 +1,6 @@
 import tensorflow as tf
-from keras.layers.normalization.layer_normalization import LayerNormalization
 from tensorflow import keras
-from tensorflow.python.keras.layers import Activation, Dense, Dropout, Layer
+from tensorflow.python.keras import layers
 
 """
 Author: Khalid Salama
@@ -9,7 +8,7 @@ https://keras.io/examples/vision/mlp_image_classification/
 """
 
 
-class Patches(Layer):
+class Patches(layers.Layer):
     def __init__(self, patch_size, num_patches):
         super().__init__()
         self.patch_size = patch_size
@@ -28,53 +27,46 @@ class Patches(Layer):
         patches = tf.reshape(patches, [batch_size, self.num_patches, patch_dims])
         return patches
 
-    class MLPMixerLayer(Layer):
-        def __init__(
-            self,
-            num_patches,
-            hidden_units,
-            dropout_rate,
-            embedding_dim,
-            *args,
-            **kwargs
-        ):
-            super().__init__(*args, **kwargs)
 
-            self.mlp1 = keras.Sequential(
-                [
-                    Dense(units=num_patches),
-                    Activation(keras.activations.gelu),
-                    Dense(units=num_patches),
-                    Dropout(rate=dropout_rate),
-                ]
-            )
-            self.mlp2 = keras.Sequential(
-                [
-                    Dense(units=num_patches),
-                    Activation(keras.activations.gelu),
-                    Dense(units=embedding_dim),
-                    Dropout(rate=dropout_rate),
-                ]
-            )
-            self.normalize = LayerNormalization(epsilon=1e-6)
+class MLPMixerLayer(layers.Layer):
+    def __init__(self, num_patches, dropout_rate, embedding_dim, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-        def call(self, inputs):
-            # Apply layer normalization.
-            x = self.normalize(inputs)
-            # Transpose inputs from [num_batches, num_patches,
-            # hidden_units] to [num_batches, hidden_units, num_patches].
-            x_channels = tf.linalg.matrix_transpose(x)
-            # Apply mlp1 on each channel independently.
-            mlp1_outputs = self.mlp1(x_channels)
-            # Transpose mlp1_outputs from [num_batches,
-            # hidden_dim, num_patches] to [num_batches, num_patches, hidden_units].
-            mlp1_outputs = tf.linalg.matrix_transpose(mlp1_outputs)
-            # Add skip connection.
-            x = mlp1_outputs + inputs
-            # Apply layer normalization.
-            x_patches = self.normalize(x)
-            # Apply mlp2 on each patch independtenly.
-            mlp2_outputs = self.mlp2(x_patches)
-            # Add skip connection.
-            x = x + mlp2_outputs
-            return x
+        self.mlp1 = keras.Sequential(
+            [
+                layers.Dense(units=num_patches),
+                layers.Activation(keras.activations.gelu),
+                layers.Dense(units=num_patches),
+                layers.Dropout(rate=dropout_rate),
+            ]
+        )
+        self.mlp2 = keras.Sequential(
+            [
+                layers.Dense(units=num_patches),
+                layers.Activation(keras.activations.gelu),
+                layers.Dense(units=embedding_dim),
+                layers.Dropout(rate=dropout_rate),
+            ]
+        )
+        self.normalize = tf.keras.layers.LayerNormalization(epsilon=1e-6)
+
+    def call(self, inputs):
+        # Apply layer normalization.
+        x = self.normalize(inputs)
+        # Transpose inputs from [num_batches, num_patches,
+        # hidden_units] to [num_batches, hidden_units, num_patches].
+        x_channels = tf.linalg.matrix_transpose(x)
+        # Apply mlp1 on each channel independently.
+        mlp1_outputs = self.mlp1(x_channels)
+        # Transpose mlp1_outputs from [num_batches,
+        # hidden_dim, num_patches] to [num_batches, num_patches, hidden_units].
+        mlp1_outputs = tf.linalg.matrix_transpose(mlp1_outputs)
+        # Add skip connection.
+        x = mlp1_outputs + inputs
+        # Apply layer normalization.
+        x_patches = self.normalize(x)
+        # Apply mlp2 on each patch independtenly.
+        mlp2_outputs = self.mlp2(x_patches)
+        # Add skip connection.
+        x = x + mlp2_outputs
+        return x

--- a/tests/test_mlp_mixer_layer.py
+++ b/tests/test_mlp_mixer_layer.py
@@ -1,0 +1,134 @@
+import tensorflow as tf
+from tensorflow import keras
+from tensorflow.keras import layers
+
+from kerasfuse.models.blocks.mlp import MLPMixerLayer, Patches
+
+"""
+Test the MLP Mixer Layer
+Based on:
+Author: Khalid Salama
+https://keras.io/examples/vision/mlp_image_classification/
+"""
+
+# Test Data Preparation
+num_classes = 100
+input_shape = (32, 32, 3)
+
+(x_train, y_train), (x_test, y_test) = keras.datasets.cifar100.load_data()
+
+print(f"x_train shape: {x_train.shape} - y_train shape: {y_train.shape}")
+print(f"x_test shape: {x_test.shape} - y_test shape: {y_test.shape}")
+
+weight_decay = 0.0001
+batch_size = 128
+num_epochs = 5
+dropout_rate = 0.2
+image_size = 64  # We'll resize input images to this size.
+patch_size = 8  # Size of the patches to be extracted from the input images.
+num_patches = (image_size // patch_size) ** 2  # Size of the data array.
+embedding_dim = 256  # Number of hidden units.
+num_blocks = 4  # Number of blocks.
+learning_rate = 0.005
+
+
+print(f"Image size: {image_size} X {image_size} = {image_size ** 2}")
+print(f"Patch size: {patch_size} X {patch_size} = {patch_size ** 2} ")
+print(f"Patches per image: {num_patches}")
+print(f"Elements per patch (3 channels): {(patch_size ** 2) * 3}")
+
+
+data_augmentation = keras.Sequential(
+    [
+        tf.keras.layers.Normalization(),
+        tf.keras.layers.Resizing(image_size, image_size),
+        tf.keras.layers.RandomFlip("horizontal"),
+        layers.RandomZoom(height_factor=0.2, width_factor=0.2),
+    ],
+    name="data_augmentation",
+)
+# Compute the mean and the variance of the training data for normalization.
+data_augmentation.layers[0].adapt(x_train)
+
+
+def build_classifier(blocks, positional_encoding=False):
+    inputs = layers.Input(shape=input_shape)
+    # Augment data.
+    augmented = data_augmentation(inputs)
+    # Create patches.
+    patches = Patches(patch_size, num_patches)(augmented)
+    # Encode patches to generate a [batch_size, num_patches, embedding_dim] tensor.
+    x = layers.Dense(units=embedding_dim)(patches)
+    if positional_encoding:
+        positions = tf.range(start=0, limit=num_patches, delta=1)
+        position_embedding = layers.Embedding(
+            input_dim=num_patches, output_dim=embedding_dim
+        )(positions)
+        x = x + position_embedding
+    # Process x using the module blocks.
+    x = blocks(x)
+    """
+    Apply global average pooling to generate
+    """
+    representation = layers.GlobalAveragePooling1D()(x)
+    # Apply dropout.
+    representation = layers.Dropout(rate=dropout_rate)(representation)
+    # Compute logits outputs.
+    logits = layers.Dense(num_classes)(representation)
+    # Create the Keras model.
+    return keras.Model(inputs=inputs, outputs=logits)
+
+
+def run_experiment(model):
+    # Create Adam optimizer with weight decay.
+    optimizer = tf.keras.optimizers.AdamW(
+        learning_rate=learning_rate,
+        weight_decay=weight_decay,
+    )
+    # Compile the model.
+    model.compile(
+        optimizer=optimizer,
+        loss=keras.losses.SparseCategoricalCrossentropy(from_logits=True),
+        metrics=[
+            keras.metrics.SparseCategoricalAccuracy(name="acc"),
+            keras.metrics.SparseTopKCategoricalAccuracy(5, name="top5-acc"),
+        ],
+    )
+    # Create a learning rate scheduler callback.
+    reduce_lr = keras.callbacks.ReduceLROnPlateau(
+        monitor="val_loss", factor=0.5, patience=5
+    )
+    # Create an early stopping callback.
+    early_stopping = tf.keras.callbacks.EarlyStopping(
+        monitor="val_loss", patience=10, restore_best_weights=True
+    )
+    # Fit the model.
+    history = model.fit(
+        x=x_train,
+        y=y_train,
+        batch_size=batch_size,
+        epochs=num_epochs,
+        validation_split=0.1,
+        callbacks=[early_stopping, reduce_lr],
+    )
+
+    _, accuracy, top_5_accuracy = model.evaluate(x_test, y_test)
+    print(f"Test accuracy: {round(accuracy * 100, 2)}%")
+    print(f"Test top 5 accuracy: {round(top_5_accuracy * 100, 2)}%")
+
+    # Return history to plot learning curves.
+    return history
+
+
+# Test the MLP Mixer Layer
+def test_mlp_mixer_layer():
+    mlpmixer_blocks = keras.Sequential(
+        [
+            MLPMixerLayer(num_patches, dropout_rate, embedding_dim)
+            for _ in range(num_blocks)
+        ]
+    )
+
+    mlpmixer_classifier = build_classifier(mlpmixer_blocks)
+    history = run_experiment(mlpmixer_classifier)
+    print(history.history)


### PR DESCRIPTION
I realize that classes should be seperated and I changed plus I created test case based on keras doc example and set to 50 epoch on my testing and changed to 10 epoch for quicker test without tfa and result

I use this one as base for comparison : https://keras.io/examples/vision/mlp_image_classification/#build-train-and-evaluate-the-mlpmixer-model

This training done under MBP-M2 with docker aarch64 tf-cpu (no metal used because of AdamW)

```
Downloading data from https://www.cs.toronto.edu/~kriz/cifar-100-python.tar.gz
169001437/169001437 [==============================] - 49s 0us/step
x_train shape: (50000, 32, 32, 3) - y_train shape: (50000, 1)
x_test shape: (10000, 32, 32, 3) - y_test shape: (10000, 1)
Image size: 64 X 64 = 4096
Patch size: 8 X 8 = 64
Patches per image: 64
Elements per patch (3 channels): 192
2023-06-17 17:08:19.732679: W tensorflow/tsl/framework/cpu_allocator_impl.cc:83] Allocation of 153600000 exceeds 10% of free system memory.
Epoch 1/50
352/352 [==============================] - 69s 191ms/step - loss: 3.8616 - acc: 0.1146 - top5-acc: 0.3211 - val_loss: 3.4993 - val_acc: 0.1772 - val_top5-acc: 0.4352 - lr: 0.0050
Epoch 2/50
352/352 [==============================] - 65s 185ms/step - loss: 3.3789 - acc: 0.1900 - top5-acc: 0.4598 - val_loss: 3.3017 - val_acc: 0.2220 - val_top5-acc: 0.4972 - lr: 0.0050
Epoch 3/50
352/352 [==============================] - 65s 185ms/step - loss: 3.1860 - acc: 0.2235 - top5-acc: 0.5143 - val_loss: 3.0873 - val_acc: 0.2528 - val_top5-acc: 0.5482 - lr: 0.0050
Epoch 4/50
352/352 [==============================] - 64s 181ms/step - loss: 3.0356 - acc: 0.2540 - top5-acc: 0.5520 - val_loss: 3.1363 - val_acc: 0.2598 - val_top5-acc: 0.5526 - lr: 0.0050
Epoch 5/50
352/352 [==============================] - 61s 174ms/step - loss: 2.9177 - acc: 0.2734 - top5-acc: 0.5787 - val_loss: 2.9032 - val_acc: 0.2914 - val_top5-acc: 0.6042 - lr: 0.0050
Epoch 6/50
352/352 [==============================] - 60s 171ms/step - loss: 2.8302 - acc: 0.2930 - top5-acc: 0.6011 - val_loss: 2.9188 - val_acc: 0.2902 - val_top5-acc: 0.5996 - lr: 0.0050
Epoch 7/50
352/352 [==============================] - 58s 166ms/step - loss: 2.7558 - acc: 0.3086 - top5-acc: 0.6199 - val_loss: 2.7418 - val_acc: 0.3294 - val_top5-acc: 0.6444 - lr: 0.0050
Epoch 8/50
352/352 [==============================] - 61s 172ms/step - loss: 2.7154 - acc: 0.3142 - top5-acc: 0.6284 - val_loss: 2.7690 - val_acc: 0.3272 - val_top5-acc: 0.6458 - lr: 0.0050
Epoch 9/50
352/352 [==============================] - 59s 168ms/step - loss: 2.6595 - acc: 0.3240 - top5-acc: 0.6378 - val_loss: 2.7346 - val_acc: 0.3300 - val_top5-acc: 0.6454 - lr: 0.0050
Epoch 10/50
352/352 [==============================] - 60s 170ms/step - loss: 2.6334 - acc: 0.3335 - top5-acc: 0.6482 - val_loss: 2.6568 - val_acc: 0.3410 - val_top5-acc: 0.6532 - lr: 0.0050
Epoch 11/50
352/352 [==============================] - 60s 171ms/step - loss: 2.5904 - acc: 0.3423 - top5-acc: 0.6562 - val_loss: 2.6038 - val_acc: 0.3578 - val_top5-acc: 0.6668 - lr: 0.0050
Epoch 12/50
352/352 [==============================] - 62s 175ms/step - loss: 2.5555 - acc: 0.3459 - top5-acc: 0.6634 - val_loss: 2.6461 - val_acc: 0.3538 - val_top5-acc: 0.6736 - lr: 0.0050
Epoch 13/50
352/352 [==============================] - 62s 176ms/step - loss: 2.5371 - acc: 0.3523 - top5-acc: 0.6664 - val_loss: 2.6196 - val_acc: 0.3600 - val_top5-acc: 0.6772 - lr: 0.0050
Epoch 14/50
352/352 [==============================] - 62s 175ms/step - loss: 2.5116 - acc: 0.3578 - top5-acc: 0.6744 - val_loss: 2.5618 - val_acc: 0.3636 - val_top5-acc: 0.6890 - lr: 0.0050
Epoch 15/50
352/352 [==============================] - 61s 175ms/step - loss: 2.4851 - acc: 0.3618 - top5-acc: 0.6791 - val_loss: 2.5702 - val_acc: 0.3712 - val_top5-acc: 0.6892 - lr: 0.0050
Epoch 16/50
352/352 [==============================] - 62s 177ms/step - loss: 2.4579 - acc: 0.3685 - top5-acc: 0.6872 - val_loss: 2.5009 - val_acc: 0.3758 - val_top5-acc: 0.6850 - lr: 0.0050
Epoch 17/50
352/352 [==============================] - 62s 175ms/step - loss: 2.4191 - acc: 0.3740 - top5-acc: 0.6942 - val_loss: 2.6088 - val_acc: 0.3686 - val_top5-acc: 0.6886 - lr: 0.0050
Epoch 18/50
352/352 [==============================] - 61s 173ms/step - loss: 2.4189 - acc: 0.3771 - top5-acc: 0.6928 - val_loss: 2.5369 - val_acc: 0.3830 - val_top5-acc: 0.6912 - lr: 0.0050
Epoch 19/50
352/352 [==============================] - 61s 174ms/step - loss: 2.4083 - acc: 0.3769 - top5-acc: 0.6968 - val_loss: 2.5827 - val_acc: 0.3712 - val_top5-acc: 0.6846 - lr: 0.0050
Epoch 20/50
352/352 [==============================] - 61s 174ms/step - loss: 2.3746 - acc: 0.3861 - top5-acc: 0.7044 - val_loss: 2.5547 - val_acc: 0.3744 - val_top5-acc: 0.6850 - lr: 0.0050
Epoch 21/50
352/352 [==============================] - 63s 179ms/step - loss: 2.3493 - acc: 0.3874 - top5-acc: 0.7089 - val_loss: 2.6062 - val_acc: 0.3680 - val_top5-acc: 0.6826 - lr: 0.0050
Epoch 22/50
352/352 [==============================] - 62s 176ms/step - loss: 2.1483 - acc: 0.4317 - top5-acc: 0.7458 - val_loss: 2.3111 - val_acc: 0.4216 - val_top5-acc: 0.7250 - lr: 0.0025
Epoch 23/50
352/352 [==============================] - 62s 176ms/step - loss: 2.0927 - acc: 0.4432 - top5-acc: 0.7575 - val_loss: 2.3508 - val_acc: 0.4200 - val_top5-acc: 0.7226 - lr: 0.0025
Epoch 24/50
352/352 [==============================] - 61s 173ms/step - loss: 2.0793 - acc: 0.4442 - top5-acc: 0.7614 - val_loss: 2.3333 - val_acc: 0.4236 - val_top5-acc: 0.7260 - lr: 0.0025
Epoch 25/50
352/352 [==============================] - 62s 177ms/step - loss: 2.0479 - acc: 0.4540 - top5-acc: 0.7660 - val_loss: 2.2702 - val_acc: 0.4340 - val_top5-acc: 0.7414 - lr: 0.0025
Epoch 26/50
352/352 [==============================] - 64s 181ms/step - loss: 2.0408 - acc: 0.4545 - top5-acc: 0.7697 - val_loss: 2.2459 - val_acc: 0.4370 - val_top5-acc: 0.7398 - lr: 0.0025
Epoch 27/50
352/352 [==============================] - 62s 177ms/step - loss: 2.0178 - acc: 0.4606 - top5-acc: 0.7718 - val_loss: 2.2864 - val_acc: 0.4332 - val_top5-acc: 0.7380 - lr: 0.0025
Epoch 28/50
352/352 [==============================] - 62s 176ms/step - loss: 2.0145 - acc: 0.4618 - top5-acc: 0.7746 - val_loss: 2.2835 - val_acc: 0.4286 - val_top5-acc: 0.7316 - lr: 0.0025
Epoch 29/50
352/352 [==============================] - 60s 170ms/step - loss: 1.9877 - acc: 0.4642 - top5-acc: 0.7757 - val_loss: 2.3196 - val_acc: 0.4260 - val_top5-acc: 0.7346 - lr: 0.0025
Epoch 30/50
352/352 [==============================] - 62s 176ms/step - loss: 1.9855 - acc: 0.4647 - top5-acc: 0.7792 - val_loss: 2.2450 - val_acc: 0.4364 - val_top5-acc: 0.7426 - lr: 0.0025
Epoch 31/50
352/352 [==============================] - 60s 169ms/step - loss: 1.9673 - acc: 0.4709 - top5-acc: 0.7825 - val_loss: 2.2511 - val_acc: 0.4414 - val_top5-acc: 0.7410 - lr: 0.0025
Epoch 32/50
352/352 [==============================] - 63s 178ms/step - loss: 1.9543 - acc: 0.4741 - top5-acc: 0.7848 - val_loss: 2.2316 - val_acc: 0.4464 - val_top5-acc: 0.7472 - lr: 0.0025
Epoch 33/50
352/352 [==============================] - 61s 174ms/step - loss: 1.9479 - acc: 0.4734 - top5-acc: 0.7852 - val_loss: 2.2895 - val_acc: 0.4354 - val_top5-acc: 0.7420 - lr: 0.0025
Epoch 34/50
352/352 [==============================] - 63s 180ms/step - loss: 1.9414 - acc: 0.4756 - top5-acc: 0.7860 - val_loss: 2.2750 - val_acc: 0.4366 - val_top5-acc: 0.7492 - lr: 0.0025
Epoch 35/50
352/352 [==============================] - 62s 178ms/step - loss: 1.9264 - acc: 0.4824 - top5-acc: 0.7891 - val_loss: 2.2005 - val_acc: 0.4514 - val_top5-acc: 0.7522 - lr: 0.0025
Epoch 36/50
352/352 [==============================] - 60s 171ms/step - loss: 1.9221 - acc: 0.4805 - top5-acc: 0.7895 - val_loss: 2.2057 - val_acc: 0.4482 - val_top5-acc: 0.7518 - lr: 0.0025
Epoch 37/50
352/352 [==============================] - 61s 172ms/step - loss: 1.9082 - acc: 0.4833 - top5-acc: 0.7912 - val_loss: 2.2121 - val_acc: 0.4510 - val_top5-acc: 0.7488 - lr: 0.0025
Epoch 38/50
352/352 [==============================] - 60s 172ms/step - loss: 1.9025 - acc: 0.4842 - top5-acc: 0.7937 - val_loss: 2.2437 - val_acc: 0.4480 - val_top5-acc: 0.7552 - lr: 0.0025
Epoch 39/50
352/352 [==============================] - 56s 158ms/step - loss: 1.8864 - acc: 0.4866 - top5-acc: 0.7954 - val_loss: 2.1998 - val_acc: 0.4502 - val_top5-acc: 0.7534 - lr: 0.0025
Epoch 40/50
352/352 [==============================] - 61s 172ms/step - loss: 1.8804 - acc: 0.4870 - top5-acc: 0.7982 - val_loss: 2.1867 - val_acc: 0.4604 - val_top5-acc: 0.7578 - lr: 0.0025
Epoch 41/50
352/352 [==============================] - 62s 175ms/step - loss: 1.8700 - acc: 0.4915 - top5-acc: 0.7988 - val_loss: 2.2443 - val_acc: 0.4366 - val_top5-acc: 0.7444 - lr: 0.0025
Epoch 42/50
352/352 [==============================] - 60s 170ms/step - loss: 1.8731 - acc: 0.4890 - top5-acc: 0.7993 - val_loss: 2.2276 - val_acc: 0.4522 - val_top5-acc: 0.7594 - lr: 0.0025
Epoch 43/50
352/352 [==============================] - 60s 170ms/step - loss: 1.8591 - acc: 0.4946 - top5-acc: 0.7991 - val_loss: 2.2235 - val_acc: 0.4412 - val_top5-acc: 0.7488 - lr: 0.0025
Epoch 44/50
352/352 [==============================] - 60s 171ms/step - loss: 1.8489 - acc: 0.4942 - top5-acc: 0.8046 - val_loss: 2.2646 - val_acc: 0.4468 - val_top5-acc: 0.7432 - lr: 0.0025
Epoch 45/50
352/352 [==============================] - 60s 169ms/step - loss: 1.8490 - acc: 0.4949 - top5-acc: 0.8060 - val_loss: 2.2622 - val_acc: 0.4472 - val_top5-acc: 0.7480 - lr: 0.0025
Epoch 46/50
352/352 [==============================] - 60s 169ms/step - loss: 1.7245 - acc: 0.5241 - top5-acc: 0.8243 - val_loss: 2.1501 - val_acc: 0.4678 - val_top5-acc: 0.7668 - lr: 0.0012
Epoch 47/50
352/352 [==============================] - 60s 170ms/step - loss: 1.6922 - acc: 0.5321 - top5-acc: 0.8303 - val_loss: 2.1429 - val_acc: 0.4678 - val_top5-acc: 0.7756 - lr: 0.0012
Epoch 48/50
352/352 [==============================] - 59s 168ms/step - loss: 1.6851 - acc: 0.5340 - top5-acc: 0.8302 - val_loss: 2.1646 - val_acc: 0.4702 - val_top5-acc: 0.7694 - lr: 0.0012
Epoch 49/50
352/352 [==============================] - 60s 169ms/step - loss: 1.6726 - acc: 0.5381 - top5-acc: 0.8332 - val_loss: 2.1599 - val_acc: 0.4714 - val_top5-acc: 0.7678 - lr: 0.0012
Epoch 50/50
352/352 [==============================] - 59s 167ms/step - loss: 1.6609 - acc: 0.5373 - top5-acc: 0.8353 - val_loss: 2.1674 - val_acc: 0.4696 - val_top5-acc: 0.7626 - lr: 0.0012
313/313 [==============================] - 7s 21ms/step - loss: 2.1346 - acc: 0.4752 - top5-acc: 0.7694
Test accuracy: 47.52%
Test top 5 accuracy: 76.94%
```


