### PR TITLE
pytest isort removed from pyproject

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,8 +48,6 @@ flake8 = "^6.0.0"
 isort = "^5.12.0"
 
 
-[tool.pytest.ini_options]
-addopts = "--isort"
 
 [tool.isort]
 line_length = 88


### PR DESCRIPTION
chore: pytest isort removed from pyproject because of pre-commit already has it